### PR TITLE
add salutem, charge-mode and sphone to hildon-meta, siwtch pp to libinput

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -200,7 +200,7 @@ Depends:
  linux-image-pine64,
  leste-config-pinephone,
  pine64-uboot,
- xserver-xorg-input-evdev,
+ xserver-xorg-input-libinput,
  iio-sensor-proxy,
  fbkeyboard,
 Description: Metapackage for installing hildon-desktop and its deps. Pinephone.

--- a/debian/control
+++ b/debian/control
@@ -60,6 +60,8 @@ Depends:
  qalendar,
  desktop-file-utils,
  profilesx,
+ salutem,
+ charge-mode,
 Provides:
  hildon-desktop-rotation-support
 Conflicts:

--- a/debian/control
+++ b/debian/control
@@ -62,6 +62,7 @@ Depends:
  profilesx,
  salutem,
  charge-mode,
+ sphone,
 Provides:
  hildon-desktop-rotation-support
 Conflicts:


### PR DESCRIPTION
adds salutem, charge-mode and sphone to hildon-meta
switches pinephone to libinput (should be drop in on pp & allows harmonic callibration between x and fbkeyboard)